### PR TITLE
Multiply battery level by 100

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ class Battery(App):
     ctx.text_align = ctx.CENTER
     ctx.text_baseline = ctx.MIDDLE
     clear_background(ctx)
-    label = f"{(BatteryLevel()/106.25):.2f}%"
+    label = f"{(BatteryLevel()/106.25)*100:.2f}%"
     ctx.move_to(0, 0).gray(1).text(label)
     ctx.restore()
 


### PR DESCRIPTION
Could be totally wrong but my badge was showing a battery level of `1.00%` when plugged in, which then dropped to `0.98%`, then `0.95%` -- so it looks like it needs multiplying by 100 😄 